### PR TITLE
フォローデータ取得機能の実装

### DIFF
--- a/rails/app/controllers/api/v1/followers_controller.rb
+++ b/rails/app/controllers/api/v1/followers_controller.rb
@@ -1,12 +1,12 @@
-class Api::V1::SupportersController < Api::V1::ApplicationController
+class Api::V1::FollowersController < Api::V1::ApplicationController
   include Pagination
   before_action :fetch_authenticated_current_user, only: [:index]
 
   def index
-    note = Note.published.find(params[:note_id])
-    users = note.supporters.
+    following = User.find(params[:user_id])
+    users = following.followers.
               includes(profile: { avatar_attachment: :blob }).
-              order("cheers.created_at DESC").
+              order("relationships.created_at DESC").
               page(params[:page] || 1).
               per(10)
     render json: users,
@@ -15,6 +15,6 @@ class Api::V1::SupportersController < Api::V1::ApplicationController
            adapter: :json,
            status: :ok
   rescue ActiveRecord::RecordNotFound
-    render json: { error: "ノートにアクセスできません" }, status: :not_found
+    render json: { error: "アカウントにアクセスできません" }, status: :not_found
   end
 end

--- a/rails/app/controllers/api/v1/followings_controller.rb
+++ b/rails/app/controllers/api/v1/followings_controller.rb
@@ -1,4 +1,20 @@
 class Api::V1::FollowingsController < Api::V1::ApplicationController
+  include Pagination
+  before_action :fetch_authenticated_current_user, only: [:index]
+
   def index
+    follower = User.find(params[:user_id])
+    users = follower.followings.
+              includes(profile: { avatar_attachment: :blob }).
+              order("relationships.created_at DESC").
+              page(params[:page] || 1).
+              per(10)
+    render json: users,
+           current_user:,
+           meta: pagination(users),
+           adapter: :json,
+           status: :ok
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: "アカウントにアクセスできません" }, status: :not_found
   end
 end

--- a/rails/app/serializers/user_serializer.rb
+++ b/rails/app/serializers/user_serializer.rb
@@ -1,5 +1,16 @@
 class UserSerializer < ActiveModel::Serializer
-  attributes :id, :cheer_points, :cheers_count
+  attributes :id,
+             :cheer_points,
+             :cheers_count,
+             :followings_count,
+             :followers_count,
+             :has_followed
 
   has_one :profile
+
+  def has_followed
+    return nil unless @instance_options[:current_user]
+
+    @instance_options[:current_user].has_followed?(object)
+  end
 end

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
       resources :users, only: [:show, :destroy] do
         resources :cheered_notes, only: [:index]
         resources :followings, only: [:index]
+        resources :followers, only: [:index]
         resource :follow, only: [:show]
       end
 

--- a/rails/spec/requests/api/v1/cheered_notes/index_spec.rb
+++ b/rails/spec/requests/api/v1/cheered_notes/index_spec.rb
@@ -7,13 +7,11 @@ RSpec.describe "Api::V1::CheeredNotes GET /api/v1/users/:user_id/cheered_notes",
   let(:user_id) { user.id }
   let(:params) { nil }
 
-  before do
-    create_list(:cheer, 20, user:)
-  end
+  before { create_list(:cheer, 20, user:) }
 
   include_examples "リソース不在エラー", "アカウント", "user_id"
 
   context "アカウントが存在する場合" do
-    include_examples "ページネーションのテスト"
+    include_examples "ページネーションのテスト", "ノート"
   end
 end

--- a/rails/spec/requests/api/v1/followers/index_spec.rb
+++ b/rails/spec/requests/api/v1/followers/index_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Followers GET /api/v1/users/:user_id/followers", type: :request do
+  subject { get(api_v1_user_followers_path(user_id, params)) }
+
+  let(:following) { create(:user) }
+  let(:user_id) { following.id }
+  let(:params) { nil }
+
+  before { create_list(:relationship, 20, following:) }
+
+  include_examples "リソース不在エラー", "アカウント", "user_id"
+  include_examples "ページネーションのテスト", "アカウント"
+end

--- a/rails/spec/requests/api/v1/followings/followings_spec.rb
+++ b/rails/spec/requests/api/v1/followings/followings_spec.rb
@@ -1,7 +1,0 @@
-require "rails_helper"
-
-RSpec.describe "Api::V1::Followings", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
-  end
-end

--- a/rails/spec/requests/api/v1/followings/index_spec.rb
+++ b/rails/spec/requests/api/v1/followings/index_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Followings GET /api/v1/users/:user_id/followings", type: :request do
+  subject { get(api_v1_user_followings_path(user_id, params)) }
+
+  let(:follower) { create(:user) }
+  let(:user_id) { follower.id }
+  let(:params) { nil }
+
+  before { create_list(:relationship, 20, follower:) }
+
+  include_examples "リソース不在エラー", "アカウント", "user_id"
+  include_examples "ページネーションのテスト", "アカウント"
+end

--- a/rails/spec/requests/api/v1/notes/index_spec.rb
+++ b/rails/spec/requests/api/v1/notes/index_spec.rb
@@ -8,5 +8,5 @@ RSpec.describe "Api::V1::Notes GET /api/v1/notes", type: :request do
     create_list(:note, 1, status: :draft)
   end
 
-  include_examples "ページネーションのテスト"
+  include_examples "ページネーションのテスト", "ノート"
 end

--- a/rails/spec/requests/api/v1/supporters/index_spec.rb
+++ b/rails/spec/requests/api/v1/supporters/index_spec.rb
@@ -1,22 +1,15 @@
 require "rails_helper"
 
 RSpec.describe "Api::V1::Supporters GET /api/v1/notes/:note_id/supporters", type: :request do
-  subject { get(api_v1_note_supporters_path(note_id)) }
+  subject { get(api_v1_note_supporters_path(note_id, params)) }
 
   let(:note) { create(:note) }
   let(:note_id) { note.id }
+  let(:params) { nil }
 
-  before { create_list(:cheer, 10, note:) }
+  before { create_list(:cheer, 20, note:) }
 
   include_examples "リソース不在エラー", "ノート", "note_id"
   include_examples "ノート非公開エラー"
-
-  context "ステータスが公開中のノートが存在する場合" do
-    it "200ステータスとユーザーの情報が返る" do
-      subject
-      expect(response).to have_http_status(:ok)
-      expect(json_response[0].keys).to eq EXPECTED_USER_KEYS
-      expect(json_response[0]["profile"].keys).to eq EXPECTED_PROFILE_KEYS
-    end
-  end
+  include_examples "ページネーションのテスト", "アカウント"
 end

--- a/rails/spec/support/shared_examples/paginated_resources_index.rb
+++ b/rails/spec/support/shared_examples/paginated_resources_index.rb
@@ -12,16 +12,29 @@ RSpec.shared_examples "ノートとページのレスポンス検証" do |page|
   end
 end
 
-RSpec.shared_examples "ページネーションのテスト" do
+RSpec.shared_examples "アカウントとページのレスポンス検証" do |page|
+  it "200ステータス、#{page}ページ目のアカウントとページの情報が返る" do
+    subject
+    expect(response).to have_http_status(:ok)
+    expect(json_response.keys).to eq ["users", "meta"]
+    expect(json_response["users"][0].keys).to eq EXPECTED_USER_KEYS
+    expect(json_response["users"][0]["profile"].keys).to eq EXPECTED_PROFILE_KEYS
+    expect(json_response["meta"].keys).to eq ["current_page", "total_pages"]
+    expect(json_response["meta"]["current_page"]).to eq page
+    expect(json_response["meta"]["total_pages"]).to eq 2
+  end
+end
+
+RSpec.shared_examples "ページネーションのテスト" do |resource_name|
   context "paramsにpageの値が含まれていない場合" do
     let(:params) { nil }
 
-    include_examples "ノートとページのレスポンス検証", 1
+    include_examples "#{resource_name}とページのレスポンス検証", 1
   end
 
   context "paramsに含まれるpageの値が2の場合" do
     let(:params) { { page: 2 } }
 
-    include_examples "ノートとページのレスポンス検証", 2
+    include_examples "#{resource_name}とページのレスポンス検証", 2
   end
 end

--- a/rails/spec/support/shared_keys.rb
+++ b/rails/spec/support/shared_keys.rb
@@ -40,5 +40,8 @@ EXPECTED_USER_KEYS = [
   "id",
   "cheer_points",
   "cheers_count",
+  "followings_count",
+  "followers_count",
+  "has_followed",
   "profile",
 ].freeze


### PR DESCRIPTION
◯フォロー先のユーザーとフォロー元のユーザー一覧データ取得
- Followingsコントローラーのindexエンドポイント
- Followersコントローラーのindexエンドポイント
◯フォロー先のユーザーの合計人数とフォロー元のユーザーの合計人数のデータ取得
- キャッシュカウンタの設定
- UserSerializerへのfollowings_countとfollowers_countカラムの追加
◯ログインユーザーが対象のユーザーをフォローしているかどうかの状態取得
- Supporters、Followings、Followersコントローラーのindexエンドポイントにおけるcurrent_userのデータ取得
- UserSerializerへのインスタンスオプションの追加とhas_followedカラムの追加